### PR TITLE
comment out turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery.turbolinks
-//= require turbolinks
+// require turbolinks
 //= require_tree .
 
 //= require bootstrap-sprockets


### PR DESCRIPTION
# what
turbolinksをコメントアウト

# why
jqueryが発火されないため(代替としてjquery-turbolinksを使用)