### PR TITLE
[fix] make modifications not to confirm action

### DIFF
--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -6,7 +6,8 @@
         <br style="clear:both">
         <h3 style="margin-bottom: 25px; text-align: center;">新規アイデア投稿</h3>
 
-        <%= form_for @article , url: {action: 'confirm'} do |f| %>
+        <%#= form_for @article , url: {action: 'confirm'} do |f| %>
+        <%= form_for @article do |f| %>
 
         <!-- バリデーションを表示 -->
         <%= render 'shared/error_messages' %>


### PR DESCRIPTION
# what
新規アイデアで投稿画面で投稿確認画面に遷移しないように修正

# why
投稿確認画面に遷移する際に画像(:fuure)の値をhidden_fieldで保持できないため
(投稿確認画面に遷移しないように一時的にしておき、今後の課題として確認画面に遷移した際に画像(:fuure)の値を保持できる方法を検討)