### PR TITLE
[fix] Fix configure_permitted_parameters in application_controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,8 +18,11 @@ class ApplicationController < ActionController::Base
   # sign_up、sign_in、account_updateの時に、usernameも許可する
   protected
     def configure_permitted_parameters
-      devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:username, :email, :password, :password_confirmation, :remember_me) }
-      devise_parameter_sanitizer.for(:sign_in) { |u| u.permit(:login, :username, :email, :password, :remember_me) }
-      devise_parameter_sanitizer.for(:account_update) { |u| u.permit(:username, :email, :password, :password_confirmation, :current_password) }
+      # sign_inのときに、username、emailも許可する
+        devise_parameter_sanitizer.permit(:sign_in, keys:[:username,:email])
+      # sign_upのときに、username、emailも許可する
+        devise_parameter_sanitizer.permit(:sign_up, keys:[:username,:email])
+      #account_updateのときに、username、emailも許可する
+        devise_parameter_sanitizer.permit(:account_update, keys:[:username,:email])
     end
 end


### PR DESCRIPTION
# what
[fix] ストロングパラメーターの設定でメソッドをdevise_parameter_sanitizer.forからdevise_parameter_sanitizer.permitに修正
# why
Devise 4.1.0以降で、devise_parameter_sanitizer.forからdevise_parameter_sanitizer.permitに変更されたため