### PR TITLE
201608261156 development fix notation of sign in sign up sign out

### DIFF
--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -36,7 +36,7 @@
               </li>
 
               <li>
-                  <%= link_to "Sign_out", destroy_user_session_path, method: :delete, class:"glyphicon glyphicon-log-out" %>
+                  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:"glyphicon glyphicon-log-out" %>
               </li>
             </ul>
           </li>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Sign inはこちら", new_session_path(resource_name) %><br />
+  <%= link_to "ログインはこちら", new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign upはこちら", new_registration_path(resource_name) %><br />
+  <%= link_to "新規会員登録はこちら", new_registration_path(resource_name) %><br />
 <% end -%>
 
 <%#- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>


### PR DESCRIPTION
# what
表記
"sign in"→"ログイン"
"sign up"→"新規会員登録"
"sign out"→"ログアウト"
に変更 
# why
表記を統一するため
