### PR TITLE
Refactoring articles_controller

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -78,4 +78,9 @@ class ArticlesController < ApplicationController
       redirect_to(root_path) unless current_user?(@article.user_id)
   end
 
+  #選択したarticleのインスタンスを取得
+  def current_article
+      @article = Article.find(params[:id])
+  end
+
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,7 @@
 class ArticlesController < ApplicationController
 
   before_action :correct_user, only: [:edit, :update]
-  before_action :current_article, only: [:show]
+  before_action :current_article, only: [:show, :edit]
 
   def show
     @review = Review.new
@@ -30,7 +30,6 @@ class ArticlesController < ApplicationController
   end
 
   def edit
-    @article = Article.find(params[:id])
   end
 
   def update

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,7 @@
 class ArticlesController < ApplicationController
 
   before_action :correct_user, only: [:edit, :update]
-  before_action :current_article, only: [:show, :edit, :update]
+  before_action :current_article, only: [:show, :edit, :update, :destroy]
 
   def show
     @review = Review.new
@@ -45,10 +45,9 @@ class ArticlesController < ApplicationController
   end
 
   def destroy
-    article = Article.find(params[:id])
-      if article.user_id == current_user.id
-        article.destroy
-      end
+    if @article.user_id == current_user.id
+        @article.destroy
+    end
     redirect_to controller: :home, action: :index
     flash[:success] = '投稿を削除しました'
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,7 @@
 class ArticlesController < ApplicationController
 
   before_action :correct_user, only: [:edit, :update]
-  before_action :current_article, only: [:show, :edit]
+  before_action :current_article, only: [:show, :edit, :update]
 
   def show
     @review = Review.new
@@ -33,8 +33,6 @@ class ArticlesController < ApplicationController
   end
 
   def update
-
-    @article = Article.find(params[:id])
     @article.update(update_params)
 
     if @article.save

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
 
-  before_action :correct_user,   only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
 
   def show
     @review = Review.new

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,7 @@
 class ArticlesController < ApplicationController
 
   before_action :correct_user, only: [:edit, :update]
+  before_action :current_article
 
   def show
     @review = Review.new

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,11 +1,10 @@
 class ArticlesController < ApplicationController
 
   before_action :correct_user, only: [:edit, :update]
-  before_action :current_article
+  before_action :current_article, only: [:show]
 
   def show
     @review = Review.new
-    @article = Article.find(params[:id])
     #退会したユーザーのレビューは表示させない
     @reviews = @article.reviews.joins(:user).includes(:user)
   end


### PR DESCRIPTION
## 目的
article_controllerのリファクタリング
## 理由
選択したarticleのインスタンスを取得する処理がアクション毎に書いており、DRYの理念に反しているため
## TODO
 - [x] 選択したarticleのインスタンスを取得するcurrent_articleメソッドを追加
 - [x] current_articleをbefore_actionに設定
 - [x] current_articleをshowアクションで実行するように設定
 - [x] current_articleをeditアクションで実行するように設定
 - [x] current_articleをupdateアクションで実行するように設定
 - [x] current_articleをdestroyアクションで実行するように設定

## 見てほしいところ
他に共通ができる処理があるかどうか

よろしくお願いします。