### PR TITLE
Fix to small font size

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -36,7 +36,7 @@
   }
   .slide-heading{
     width:    100%;
-    font-size:  150%;
+    font-size:  20px;
     text-align: center;
     bottom:   4px;
     margin:   0;
@@ -86,4 +86,3 @@
   }
 
 }
-


### PR DESCRIPTION
## 目的
スライドのタイトルの文字サイズを小さくなるように修正
## 理由
もう少し小さい方がバランスとして良いと考えたため

## 修正前
<img width="1278" alt="2" src="https://cloud.githubusercontent.com/assets/19608290/23100956/c83343f4-f6ce-11e6-9cd9-d94f39901e19.png">

## 修正後
<img width="1280" alt="2" src="https://cloud.githubusercontent.com/assets/19608290/23100957/cce350ec-f6ce-11e6-8900-7b3b52437ef8.png">