### PR TITLE
Add scss_lint to gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'byebug'
   gem "rspec-rails", "~> 3.1.0"
   gem "factory_girl_rails", "~> 4.4.1"
-
+  gem 'scss_lint', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scss_lint (0.52.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -428,6 +431,7 @@ DEPENDENCIES
   rmagick
   rspec-rails (~> 3.1.0)
   sass-rails (~> 5.0)
+  scss_lint
   sdoc (~> 0.4.0)
   selenium-webdriver (~> 2.43.0)
   spring


### PR DESCRIPTION
## 目的
scss_lintの追加
## 理由
.scssファイルの構文チェックを行い、可読性を上げるため